### PR TITLE
perf: select_related('user') en AudioList

### DIFF
--- a/redpanal/redpanal/api.py
+++ b/redpanal/redpanal/api.py
@@ -120,7 +120,7 @@ class AudioList(generics.ListAPIView):
     search_fields = ['name', 'description', 'tags__name', 'user__username']
 
     def get_queryset(self):
-        queryset = Audio.objects.all()
+        queryset = Audio.objects.select_related('user')
 
         filter_data = {}
         username = self.request.query_params.get('user', None)


### PR DESCRIPTION
## Que hace

Agrega  al queryset de .

## Por que

Sin este cambio Django hace una query SQL extra por cada audio para cargar el usuario relacionado (problema N+1). Con 80 audios por request = 80 queries adicionales innecesarias.

## Resultado

El campo  en  ahora devuelve el objeto completo  en lugar del ID entero. El  ya tenia  correctamente definido — solo faltaba el JOIN.

## Test

- [ ]  devuelve 
- [ ] Sin regresiones en filtros: , , , busqueda